### PR TITLE
excludeOriginHeaders feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ $ npm install @optum/openid-client-server
 with yarn
 
 ```console
-$ yarn add @ooptum/openid-client-server
+$ yarn add @optum/openid-client-server
 ```
 
 ## Usage

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -113,10 +113,15 @@ export const createMiddleware = (
 
     if (proxyOptions.proxyPaths.length === proxyOptions.proxyHosts.length) {
         let excludeCookie = false
+        let excludeOriginHeaders = false
         let useIdToken = false
         const includeCookieFlag = proxyOptions.excludeCookie
             ? proxyOptions.proxyPaths.length ===
               proxyOptions.excludeCookie.length
+            : false
+        const includeOriginHeadersFlag = proxyOptions.excludeOriginHeaders
+            ? proxyOptions.proxyPaths.length ===
+              proxyOptions.excludeOriginHeaders.length
             : false
         const includeUseIdTokenFlag = proxyOptions.excludeCookie
             ? proxyOptions.proxyPaths.length ===
@@ -130,6 +135,10 @@ export const createMiddleware = (
                 excludeCookie = proxyOptions.excludeCookie[i]
             }
 
+            if (includeOriginHeadersFlag) {
+                excludeOriginHeaders = proxyOptions.excludeOriginHeaders[i]
+            }
+
             if (includeUseIdTokenFlag) {
                 useIdToken = proxyOptions.useIdToken[i]
             }
@@ -140,6 +149,7 @@ export const createMiddleware = (
                         host: proxyHost,
                         pathname: proxyPath,
                         excludeCookie,
+                        excludeOriginHeaders,
                         useIdToken,
                         sessionStore,
                         client

--- a/src/middleware/proxy-middleware.ts
+++ b/src/middleware/proxy-middleware.ts
@@ -11,6 +11,7 @@ export const proxyMiddleware = (
         host,
         pathname,
         excludeCookie,
+        excludeOriginHeaders,
         useIdToken,
         sessionStore,
         client
@@ -80,6 +81,7 @@ export const proxyMiddleware = (
             await executeRequest({
                 token,
                 excludeCookie,
+                excludeOriginHeaders,
                 host,
                 pathname,
                 ctx,

--- a/src/middleware/types.ts
+++ b/src/middleware/types.ts
@@ -23,6 +23,7 @@ export interface ProxyParams {
     host: string
     pathname: string
     excludeCookie: boolean
+    excludeOriginHeaders: boolean
     useIdToken: boolean
     sessionStore: SessionStore
     client: Client
@@ -31,6 +32,7 @@ export interface ProxyParams {
 export interface ExecuteProxyRequestParams {
     token: string
     excludeCookie: boolean
+    excludeOriginHeaders: boolean
     host: string
     pathname: string
     ctx: Context

--- a/src/middleware/util.ts
+++ b/src/middleware/util.ts
@@ -190,7 +190,15 @@ export const pathFromReferer = (referer: string): string => {
 export const executeRequest = async (
     executeParams: ExecuteProxyRequestParams
 ): Promise<void> => {
-    const {token, excludeCookie, host, pathname, ctx, method} = executeParams
+    const {
+        token,
+        excludeCookie,
+        excludeOriginHeaders,
+        host,
+        pathname,
+        ctx,
+        method
+    } = executeParams
     const {headers} = ctx.req
     const {path} = ctx.url
     let body = ''
@@ -205,7 +213,11 @@ export const executeRequest = async (
         body = await parseBody(ctx.req)
     }
 
-    const reqHeaders = clone(headers)
+    let reqHeaders = clone(headers)
+
+    if (excludeOriginHeaders) {
+        reqHeaders = {}
+    }
 
     reqHeaders.authorization = `Bearer ${token}`
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -35,6 +35,7 @@ export interface ProxyOptions {
     proxyHosts: string[]
     excludeCookie: boolean[]
     useIdToken: boolean[]
+    excludeOriginHeaders: boolean[]
 }
 
 export interface Options {
@@ -370,6 +371,13 @@ const proxyOptionsEnvMapItems: EnvMapItem[] = [
     {
         propKey: 'useIdToken',
         envKey: 'OPENID_PROXY_USE_ID_TOKEN',
+        defaultValue: [false],
+        required: false,
+        skipIfNotRequired: true
+    },
+    {
+        propKey: 'excludeOriginHeaders',
+        envKey: 'OPENID_PROXY_EXCLUDE_ORIGIN_HEADERS',
         defaultValue: [false],
         required: false,
         skipIfNotRequired: true

--- a/test/helpers/test-options.ts
+++ b/test/helpers/test-options.ts
@@ -38,6 +38,7 @@ export const testOptions: Options = {
         proxyPaths: [],
         proxyHosts: [],
         excludeCookie: [],
+        excludeOriginHeaders: [],
         useIdToken: []
     }
 }
@@ -56,6 +57,7 @@ export const testOptionsWithProxy: Options = {
         proxyPaths: ['/proxy'],
         proxyHosts: ['https://host.test'],
         excludeCookie: [false],
+        excludeOriginHeaders: [false],
         useIdToken: [false]
     }
 }

--- a/test/middleware/create-middleware.test.ts
+++ b/test/middleware/create-middleware.test.ts
@@ -33,6 +33,7 @@ test('createMiddleware should initialize a Pipeline without proxy paths as expec
         proxyPaths: [],
         proxyHosts: [],
         excludeCookie: [],
+        excludeOriginHeaders: [],
         useIdToken: []
     }
 

--- a/test/middleware/proxy/access-denied-no-refresh-token-when-expired.test.ts
+++ b/test/middleware/proxy/access-denied-no-refresh-token-when-expired.test.ts
@@ -20,12 +20,14 @@ test('proxyMiddlware should throw access denied when no refresh token is present
     const host = 'http://unit-test:0000'
     const pathname = '/unit-test-proxy'
     const excludeCookie = false
+    const excludeOriginHeaders = false
     const useIdToken = false
 
     const proxy = proxyMiddleware({
         host,
         pathname,
         excludeCookie,
+        excludeOriginHeaders,
         useIdToken,
         sessionStore: store,
         client: clientStub

--- a/test/middleware/proxy/access-denied-no-session-id.test.ts
+++ b/test/middleware/proxy/access-denied-no-session-id.test.ts
@@ -19,12 +19,14 @@ test('proxyMiddlware should throw access denied when no session id is present', 
     const host = 'http://unit-test:0000'
     const pathname = '/unit-test-proxy'
     const excludeCookie = false
+    const excludeOriginHeaders = false
     const useIdToken = false
 
     const proxy = proxyMiddleware({
         host,
         pathname,
         excludeCookie,
+        excludeOriginHeaders,
         useIdToken,
         sessionStore: store,
         client: clientStub

--- a/test/middleware/proxy/access-denied-no-session-tokenset.test.ts
+++ b/test/middleware/proxy/access-denied-no-session-tokenset.test.ts
@@ -19,12 +19,14 @@ test('proxyMiddlware should throw access denied when no session id is present', 
     const host = 'http://unit-test:0000'
     const pathname = '/unit-test-proxy'
     const excludeCookie = false
+    const excludeOriginHeaders = false
     const useIdToken = false
 
     const proxy = proxyMiddleware({
         host,
         pathname,
         excludeCookie,
+        excludeOriginHeaders,
         useIdToken,
         sessionStore: store,
         client: clientStub

--- a/test/middleware/proxy/access-denied-no-session.test.ts
+++ b/test/middleware/proxy/access-denied-no-session.test.ts
@@ -19,12 +19,15 @@ test('proxyMiddlware should throw access denied when no session id is present', 
     const host = 'http://unit-test:0000'
     const pathname = '/unit-test-proxy'
     const excludeCookie = false
+    const excludeOriginHeaders = false
+
     const useIdToken = false
 
     const proxy = proxyMiddleware({
         host,
         pathname,
         excludeCookie,
+        excludeOriginHeaders,
         useIdToken,
         sessionStore: store,
         client: clientStub

--- a/test/middleware/proxy/refresh-expired-and-execute-request.test.ts
+++ b/test/middleware/proxy/refresh-expired-and-execute-request.test.ts
@@ -20,6 +20,8 @@ test('proxyMiddlware should refresh token when expired and execute request', asy
     const testHost = 'http://unit-test:0000'
     const testPathname = '/unit-test-proxy'
     const testExcludeCookie = false
+    const testExcludeOriginHeaders = false
+
     const testUseIdToken = false
     const testRefreshToken = 'test-refresh-token'
     const testAccessToken = 'test-access-token'
@@ -38,6 +40,7 @@ test('proxyMiddlware should refresh token when expired and execute request', asy
         host: testHost,
         pathname: testPathname,
         excludeCookie: testExcludeCookie,
+        excludeOriginHeaders: testExcludeOriginHeaders,
         useIdToken: testUseIdToken,
         sessionStore: store,
         client: clientStub

--- a/test/middleware/util/execute-request.test.ts
+++ b/test/middleware/util/execute-request.test.ts
@@ -18,6 +18,7 @@ test.before('setup nock', () => {
 test('executeRequest should fetch from expected url', async t => {
     const testToken = 'totally-a-legit-token'
     const testExcludeCookie = false
+    const testExcludeOriginHeaders = false
     const testMethod = 'post'
     const testPathname = '/widgets'
     const testProxyPathname = '/proxy'
@@ -41,6 +42,7 @@ test('executeRequest should fetch from expected url', async t => {
     await executeRequest({
         token: testToken,
         excludeCookie: testExcludeCookie,
+        excludeOriginHeaders: testExcludeOriginHeaders,
         host: testProxyHost,
         pathname: testProxyPathname,
         ctx: testContext,


### PR DESCRIPTION
### Description:

I found in _some_ instances, like using the proxy feature to call and IDP's `/userinfo` endpoint, that passing all the origin headers along with the proxy call causes certificate issues when calling from localhost. This feature allows to opt out of cloning all origin headers for any of the configured proxy endpoints.

Please provide the following context related to your pull request:
- [x] Change is code complete and matches issue description
- [ x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [ x] I have performed a self-review of my code
- [ x] My code follows the code style of this project
- [ x] I have added appropriate tests and all tests pass
